### PR TITLE
Removing tags because posts are being shown twice

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,10 +4,6 @@ main:
   #   url: https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/
   - title: "About"
     url: /about/
-  - title: Tags
-    url: /tags/
-  - title: "Machine Learning"
-    url: /tags/machine-learning/
   # - title: "Sample Posts"
   #   url: /year-archive/
   # - title: "Sample Collections"

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ author_profile: true
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="theme-color" content="#ffffff">
 
-<h3 class="archive__subtitle">Recent Posts</h3>
+<h3 class="archive__subtitle">Posts</h3>
 
 {% assign items_grouped = paginator.posts | group_by: 'ref' %}
 {% for group in items_grouped %}


### PR DESCRIPTION
I had to remove tags because posts with translation were being shown twice. I probably have to work on collections or archives. Because I still have only one post I think it's OK to show them only on the Home Page.