### PR TITLE
Changing wrong terminology

### DIFF
--- a/_posts/2020-11-04-data-bytes-data-privacy-en.md
+++ b/_posts/2020-11-04-data-bytes-data-privacy-en.md
@@ -10,7 +10,7 @@ header:
 
 ---
 
-(Image taken from [here](https://www.onlineretailtoday.com/security/))
+(Image taken from [here](https://www.bigcommerce.com/blog/consumer-data-privacy/))
 
 The Data Protection Law in Brazil is already a reality. Effective since [September 18 this year](https://agenciabrasil.ebc.com.br/geral/noticia/2020-09/entenda-o-que-muda-com-a-lei-geral-de-protecao-de-dados), the LGPD defines a set of rules to define limits, conditions for the collection, storage and treatment of personal information. One of the pillars of [LGPD](http://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/L13709.htm) is **data privacy**, according to Art. 1: *"with the objective of protecting the fundamental rights of freedom and privacy"* and also item I of Art. 2: *"The discipline of the protection of personal data is based on: respect for privacy"*.
 
@@ -22,7 +22,7 @@ A good place to start the discussion is to define privacy; this definition alone
 
 ### Privacy and Anonymization
 
-It is very important to keep in mind that the concepts of privacy and anonymization are not identical and that anonymized data does not correspond to secure data or privacy. This point is not always very obvious because if we take a *dataset* as independent from others, in a vacuum, anonymization may seem sufficient to guarantee privacy.
+It is very important to keep in mind that the concepts of privacy and anonymization are not identical and that anonymized data does not correspond to privacy. This point is not always very obvious because if we take a *dataset* as independent from others, in a vacuum, anonymization may seem sufficient to guarantee privacy.
 
 However, anonymization fails in privacy when we take other data sources to identify an individual; that is to say that even if a *dataset* is anonymized, information contained in another *dataset* can be used to identify individuals.
 

--- a/_posts/2020-11-04-data-bytes-data-privacy-pt_BR.md
+++ b/_posts/2020-11-04-data-bytes-data-privacy-pt_BR.md
@@ -9,7 +9,7 @@ header:
   image: "/images/data-bytes/data-privacy/theme.png"
 ---
 
-(Imagem tirada [daqui](https://www.onlineretailtoday.com/security/))
+(Imagem tirada [daqui](https://www.bigcommerce.com/blog/consumer-data-privacy/))
 
 A Lei de Proteção de Dados no Brasil já é uma realidade. Em vigor desde o dia [18 de setembro deste ano](https://agenciabrasil.ebc.com.br/geral/noticia/2020-09/entenda-o-que-muda-com-a-lei-geral-de-protecao-de-dados), a LGPD define um conjunto de normas para definir limites, condições de coleta, guarda e tratamento de informações pessoais. Um dos pilares da [LGPD](http://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/L13709.htm) é a **privacidade de dados**, conforme o Art. 1o: *"com o objetivo de proteger os direitos fundamentais de liberdade e de privacidade"* e também o inciso I do Art. 2o: *"A disciplina da proteção de dados pessoais tem como fundamentos: o respeito à privacidade"*.
 
@@ -21,7 +21,7 @@ Um bom lugar para começar a discussão é definir o que é privacidade; esta de
 
 ### Privacidade e Anonimização
 
-É muito importante ter em mente que os conceitos de privacidade e anonimização não são idênticos e que dados anonimizados não correspondem à dados seguros ou à privacidade. Este ponto nem sempre é muito óbvio porque se tomamos um *dataset* (um conjunto de dados) como independente de outros, em um vácuo, a anonimização pode parecer suficiente para garantia de privacidade.
+É muito importante ter em mente que os conceitos de privacidade e anonimização não são idênticos e que dados anonimizados não correspondem à dados privados (ou privacidade). Este ponto nem sempre é muito óbvio porque se tomamos um *dataset* (um conjunto de dados) como independente de outros, em um vácuo, a anonimização pode parecer suficiente para garantia de privacidade.
 
 No entanto, a anonimização falha em privacidade quando tomamos outras fontes de dados para identificar um indivíduo; isto é dizer que mesmo que um *dataset* esteja anonimizado, informações contidas em outro *dataset* podem ser utilizadas para identificar indivíduos.
 
@@ -99,4 +99,4 @@ Phillips D. **Data Privacy vs. Data Security: What is the Core Difference?**. Di
 
 Vitillo R. **Differential Privacy for Dummies**. Disponível em: https://robertovitillo.com/differential-privacy-for-dummies/
 
-Harvard University Privacy Tools Project. **Differential Privacy.** Disponível em: https://privacytools.seas.harvard.edu/differential-privacy
+Harvard University Privacy Tools Project. **Differential Privacy.** Disponível em: https://privacytools.seas.harvard.edu/differential-privacyc


### PR DESCRIPTION
There was an error regarding terminology on _pt_BR_ and _en_: there was something like security = privacy. 